### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install sphinx-termynal
    ```python
    extensions = [
        ...
-       'sphynx_termynal',
+       "sphinx_termynal",
        ...
    ]
    

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -20,7 +20,7 @@ Create animated terminal window in your [Sphinx](https://www.sphinx-doc.org) doc
 ```{code-block} python
    extensions = [
        ...
-       'sphynx_termynal',
+       "sphynx_terminal",
        ...
    ]
 ```


### PR DESCRIPTION
Was:

```python
   extensions = [
       ...
       'sphynx_termynal',
       ...
   ]
```

Changed to:

```python
   extensions = [
       ...
       "sphinx_termynal",
       ...
   ]
```